### PR TITLE
Fix hardcoding of font set name in dist dir

### DIFF
--- a/.nixpkgs/pkgs/iosevka/default.nix
+++ b/.nixpkgs/pkgs/iosevka/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     fontdir=$out/share/fonts/truetype
     mkdir -p $fontdir
-    cp -v dist/iosevka-custom/* $fontdir
+    cp -v dist/iosevka-${set}/* $fontdir
   '';
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
The font should be placed in »iosevka-${set}«, not in »iosevka-custom«. This was likely an oversight due to the fact that »custom« is the default value for »${set}«. Without this change, any other $set will result in a bad parameter given to cp in the installation phase.